### PR TITLE
Refactor home page into modular components and hooks

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,211 +1,61 @@
 "use client";
-import { useEffect, useState, useRef } from "react";
-import { API_BASE } from "@/lib/api";
-import Image from "next/image";
+
+import { LogoHeader } from "@/components/LogoHeader";
+import { CatalogSelector } from "@/components/CatalogSelector";
+import { GenerateButton } from "@/components/GenerateButton";
 import SearchTela from "@/components/SearchTela";
-
-type Color = {
-  color_id: string;
-  name: string;
-  hex: string;
-  swatch_url?: string | null;
-};
-type Family = {
-  family_id: string;
-  display_name: string;
-  status: "active" | "inactive";
-  sort: number;
-  colors: Color[];
-};
-type CatalogResponse = { families: Family[] };
-
-type Cut = "recto" | "cruzado";
+import { ImageUploadControls } from "@/components/ImageUploadControls";
+import { GeneratedImageGallery } from "@/components/GeneratedImageGallery";
+import { ImageModal } from "@/components/ImageModal";
+import { LoadingState } from "@/components/LoadingState";
+import { EmptyState } from "@/components/EmptyState";
+import { useVirtualStylist } from "@/hooks/useVirtualStylist";
 
 export default function Home() {
-  const [catalog, setCatalog] = useState<CatalogResponse>({ families: [] });
-  const [familyId, setFamilyId] = useState<string>("");
-  const [colorId, setColorId] = useState<string>("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [images, setImages] = useState<
-    { cut: Cut; url: string; width: number; height: number }[]
-  >([]);
-  const [selected, setSelected] = useState<{
-    url: string;
-    cut: Cut;
-    width: number;
-    height: number;
-  } | null>(null);
-  const [preview, setPreview] = useState<
-    { url: string; name: string; width: number; height: number } | null
-  >(null);
-  const galleryInputRef = useRef<HTMLInputElement | null>(null);
-  const cameraInputRef = useRef<HTMLInputElement | null>(null);
-  const previewUrlRef = useRef<string | null>(null);
+  const {
+    catalog,
+    families,
+    catalogError,
+    familyId,
+    colorId,
+    isGenerating,
+    generationError,
+    images,
+    selectedImage,
+    preview,
+    galleryInputRef,
+    cameraInputRef,
+    selectFamily,
+    selectColor,
+    generate,
+    handleFileSelection,
+    openGalleryPicker,
+    openCameraPicker,
+    openImage,
+    closeImage,
+  } = useVirtualStylist();
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const res = await fetch(`${API_BASE}/catalog`);
-        const data = await res.json();
-        setCatalog(data);
-        // Preselect first active family/color
-        const fam =
-          data.families.find((f: Family) => f.status === "active") ||
-          data.families[0];
-        if (fam) {
-          setFamilyId(fam.family_id);
-          if (fam.colors?.length) setColorId(fam.colors[0].color_id);
-        }
-      } catch (err) {
-        console.error(err);
-        setError("No se pudo cargar el catálogo");
-      }
-    })();
-  }, []);
-
-  // Disable scroll
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setSelected(null);
-    }
-    if (selected) {
-      document.addEventListener("keydown", onKey);
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.removeEventListener("keydown", onKey);
-      document.body.style.overflow = "";
-    };
-  }, [selected]);
-
-  const currentFamily = catalog.families.find((f) => f.family_id === familyId);
-
-  useEffect(() => {
-    return () => {
-      if (previewUrlRef.current) {
-        URL.revokeObjectURL(previewUrlRef.current);
-      }
-    };
-  }, []);
-
-  function handlePreview(files: FileList | null) {
-    const file = files?.[0];
-    if (!file) return;
-    if (previewUrlRef.current) {
-      URL.revokeObjectURL(previewUrlRef.current);
-    }
-    const url = URL.createObjectURL(file);
-    previewUrlRef.current = url;
-    const img = new window.Image();
-    img.onload = () => {
-      setPreview({
-        url,
-        name: file.name,
-        width: img.naturalWidth || img.width,
-        height: img.naturalHeight || img.height,
-      });
-    };
-    img.onerror = () => {
-      setPreview({ url, name: file.name, width: 400, height: 400 });
-    };
-    img.src = url;
-  }
-
-  async function onGenerate() {
-    setLoading(true);
-    setError(null);
-    setImages([]);
-    try {
-      const res = await fetch(`${API_BASE}/generate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          family_id: familyId,
-          color_id: colorId,
-          cuts: ["recto", "cruzado"],
-          quality: "final",
-        }),
-      });
-      if (!res.ok) throw new Error("API error");
-      const data = await res.json();
-      setImages(data.images || []);
-    } catch (err) {
-      console.error(err);
-      setError("No pudimos generar las imágenes. Probemos otra combinación.");
-    } finally {
-      setLoading(false);
-    }
-  }
+  const disableGenerate = isGenerating || !familyId || !colorId;
+  const errorMessage = generationError ?? catalogError;
+  const showEmptyState = images.length === 0 && !isGenerating;
 
   return (
     <main className="min-h-screen max-w-4xl mx-auto p-6">
-      <header className="mb-6 flex items-center justify-between">
-        <Image
-          src="/logo-transparent.webp"
-          alt="Harris & Frank logo"
-          width={180} // adjust to your design
-          height={60}
-          priority
-        />
-      </header>
+      <LogoHeader />
 
       <section className="grid gap-4 md:grid-cols-3">
-        {/* Left controls */}
         <div className="md:col-span-1 space-y-4">
-          <div>
-            <label className="text-sm block mb-1">Familia de tela</label>
-            <select
-              className="border rounded p-2 w-full"
-              value={familyId}
-              onChange={(e) => {
-                setFamilyId(e.target.value);
-                setColorId("");
-              }}
-            >
-              {catalog.families.map((f) => (
-                <option
-                  className="text-black"
-                  key={f.family_id}
-                  value={f.family_id}
-                >
-                  {f.display_name}
-                </option>
-              ))}
-            </select>
-          </div>
+          <CatalogSelector
+            families={families}
+            selectedFamilyId={familyId}
+            selectedColorId={colorId}
+            onFamilyChange={selectFamily}
+            onColorSelect={selectColor}
+          />
 
-          <div>
-            <label className="text-sm block mb-1">Tela</label>
-            <div className="grid grid-cols-3 gap-2">
-              {currentFamily?.colors?.map((c) => (
-                <button
-                  key={c.color_id}
-                  onClick={() => setColorId(c.color_id)}
-                  className={`border rounded p-2 text-sm hover:border-gray-500 ${
-                    colorId === c.color_id ? "ring-1 ring-white" : ""
-                  }`}
-                  title={c.name}
-                >
-                  <div
-                    className="w-full h-10 md:h-14 lg:h-16 rounded mb-1"
-                    style={{ backgroundColor: c.hex }}
-                  />
-                  <div className="truncate">{c.name}</div>
-                </button>
-              ))}
-            </div>
-          </div>
+          <GenerateButton onClick={generate} disabled={disableGenerate} loading={isGenerating} />
 
-          <button
-            onClick={onGenerate}
-            disabled={loading || !familyId || !colorId}
-            className="w-full bg-black text-white py-2 rounded disabled:opacity-50 hover:border hover:border-white"
-          >
-            {loading ? "Generando..." : "Generar imagenes"}
-          </button>
-
-          {error && <div className="text-red-600 text-sm">{error}</div>}
+          {errorMessage && <div className="text-red-600 text-sm">{errorMessage}</div>}
 
           <div className="w-full flex text-white py-2 justify-center">O</div>
 
@@ -213,170 +63,32 @@ export default function Home() {
             catalog={catalog}
             currentFamilyId={familyId}
             currentColorId={colorId}
-            onSelect={(famId, colId) => {
-              setFamilyId(famId);
-              setColorId(colId);
+            onSelect={(nextFamilyId, nextColorId) => {
+              selectFamily(nextFamilyId);
+              selectColor(nextColorId);
             }}
-            // Later you can inject a real resolver:
-            // resolveTelaId={async (telaId) => {
-            //   const res = await fetch(`${API_BASE}/catalog/search?color_id=${encodeURIComponent(telaId)}`);
-            //   if (!res.ok) return null;
-            //   return res.json(); // { familyId, colorId }
-            // }}
           />
 
-          <div className="space-y-2">
-            <input
-              ref={galleryInputRef}
-              type="file"
-              accept="image/*"
-              className="hidden"
-              onChange={(event) => {
-                handlePreview(event.target.files);
-                event.target.value = "";
-              }}
-            />
-            <input
-              ref={cameraInputRef}
-              type="file"
-              accept="image/*"
-              capture="environment"
-              className="hidden"
-              onChange={(event) => {
-                handlePreview(event.target.files);
-                event.target.value = "";
-              }}
-            />
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <button
-                type="button"
-                className="w-full rounded border border-white/20 bg-white/10 px-3 py-2 text-sm text-white hover:bg-white/20"
-                onClick={() => galleryInputRef.current?.click()}
-              >
-                Elegir foto
-              </button>
-              <button
-                type="button"
-                className={[
-                  "w-full rounded border border-white/20 bg-white/10 px-3 py-2 text-sm text-white hover:bg-white/20",
-                  "md:hidden",
-                ].join(" ")}
-                onClick={() => cameraInputRef.current?.click()}
-              >
-                Tomar foto
-              </button>
-            </div>
-            {preview && (
-              <div className="space-y-2">
-                <div className="text-sm text-white/70">Vista previa</div>
-                <div className="overflow-hidden rounded border border-white/10 bg-black/20">
-                  <Image
-                    src={preview.url}
-                    alt={`Vista previa de ${preview.name}`}
-                    width={preview.width || 400}
-                    height={preview.height || 400}
-                    className="h-auto w-full object-cover"
-                    unoptimized
-                  />
-                </div>
-              </div>
-            )}
-          </div>
+          <ImageUploadControls
+            galleryInputRef={galleryInputRef}
+            cameraInputRef={cameraInputRef}
+            onFileChange={handleFileSelection}
+            onOpenGallery={openGalleryPicker}
+            onOpenCamera={openCameraPicker}
+            preview={preview}
+          />
         </div>
 
-        {/* Right preview */}
-        <div className="md:col-span-2">
-          {images.length === 0 && !loading && (
-            <div className="border rounded p-6 text-neutral-500">
-              Elige familia y color, luego presiona Generar.
-            </div>
-          )}
+        <div className="md:col-span-2 space-y-4">
+          {showEmptyState && <EmptyState />}
 
-          {/* Loading state */}
-          {loading && (
-            <div className="border rounded p-6 text-neutral-600 space-y-2">
-              <div className="animate-pulse text-white">
-                Inicializando modelo…
-              </div>
-              <div className="animate-pulse text-white">
-                Aplicando textura de tela…
-              </div>
-              <div className="animate-pulse text-white">
-                Renderizando vistas recto y cruzado…
-              </div>
-            </div>
-          )}
+          {isGenerating && <LoadingState />}
 
-          {/* Generated images */}
-          {images.length > 0 && (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {images.map((img) => (
-                <figure key={img.cut} className="border rounded p-2">
-                  <Image
-                    src={img.url}
-                    alt={img.cut}
-                    width={img.width || 800}
-                    height={img.height || 1200}
-                    className="w-full h-auto rounded cursor-zoom-in"
-                    sizes="(min-width: 768px) 50vw, 100vw"
-                    onClick={() => setSelected(img)}
-                  />
-                  <figcaption className="text-sm mt-1 capitalize">
-                    {img.cut}
-                  </figcaption>
-                </figure>
-              ))}
-            </div>
-          )}
+          <GeneratedImageGallery images={images} onSelect={openImage} />
         </div>
       </section>
 
-      {/* Modal */}
-      {selected && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center"
-          aria-modal="true"
-          role="dialog"
-        >
-          {/* Backdrop (click to close) */}
-          <div
-            className="absolute inset-0 bg-black/70"
-            onClick={() => setSelected(null)}
-          />
-
-          {/* Dialog */}
-          <div
-            className="relative max-w-5xl w-[92vw] md:w-auto p-0"
-            onClick={(e) => e.stopPropagation()} // prevent closing when clicking image
-          >
-            {/* Close button (optional but handy) */}
-            <button
-              aria-label="Cerrar"
-              className="absolute -top-10 right-0 md:top-2 md:-right-10 bg-white/10 hover:bg-white/20 text-white rounded-full px-3 py-1 text-sm"
-              onClick={() => setSelected(null)}
-            >
-              ✕
-            </button>
-
-            {/* The image */}
-            <Image
-              src={selected.url}
-              alt={selected.cut}
-              width={selected.width || 1200}
-              height={selected.height || 1600}
-              className="rounded shadow-lg max-h-[85vh] w-auto h-auto"
-              // If your source images are already optimized or huge/remote and
-              // you want to bypass optimization, you can add: unoptimized
-              // unoptimized
-              sizes="85vh"
-              priority
-            />
-            <div className="mt-2 text-center text-sm text-white/80 capitalize">
-              {selected.cut} · Toca fuera para cerrar
-            </div>
-          </div>
-        </div>
-      )}
+      <ImageModal image={selectedImage} onClose={closeImage} />
     </main>
   );
 }

--- a/frontend/src/components/CatalogSelector.tsx
+++ b/frontend/src/components/CatalogSelector.tsx
@@ -1,0 +1,61 @@
+import { Family } from "@/types/catalog";
+
+type CatalogSelectorProps = {
+  families: Family[];
+  selectedFamilyId: string;
+  selectedColorId: string;
+  onFamilyChange: (familyId: string) => void;
+  onColorSelect: (colorId: string) => void;
+};
+
+export function CatalogSelector({
+  families,
+  selectedFamilyId,
+  selectedColorId,
+  onFamilyChange,
+  onColorSelect,
+}: CatalogSelectorProps) {
+  const activeFamily = families.find((family) => family.family_id === selectedFamilyId);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="text-sm block mb-1">Familia de tela</label>
+        <select
+          className="border rounded p-2 w-full"
+          value={selectedFamilyId}
+          onChange={(event) => onFamilyChange(event.target.value)}
+        >
+          {families.map((family) => (
+            <option className="text-black" key={family.family_id} value={family.family_id}>
+              {family.display_name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="text-sm block mb-1">Tela</label>
+        <div className="grid grid-cols-3 gap-2">
+          {activeFamily?.colors?.map((color) => (
+            <button
+              key={color.color_id}
+              onClick={() => onColorSelect(color.color_id)}
+              className={`border rounded p-2 text-sm hover:border-gray-500 ${
+                selectedColorId === color.color_id ? "ring-1 ring-white" : ""
+              }`}
+              title={color.name}
+              type="button"
+            >
+              <div
+                className="w-full h-10 md:h-14 lg:h-16 rounded mb-1"
+                style={{ backgroundColor: color.hex }}
+              />
+              <div className="truncate">{color.name}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,7 @@
+export function EmptyState() {
+  return (
+    <div className="border rounded p-6 text-neutral-500">
+      Elige familia y color, luego presiona Generar.
+    </div>
+  );
+}

--- a/frontend/src/components/GenerateButton.tsx
+++ b/frontend/src/components/GenerateButton.tsx
@@ -1,0 +1,18 @@
+type GenerateButtonProps = {
+  onClick: () => void;
+  disabled: boolean;
+  loading: boolean;
+};
+
+export function GenerateButton({ onClick, disabled, loading }: GenerateButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="w-full bg-black text-white py-2 rounded disabled:opacity-50 hover:border hover:border-white"
+      type="button"
+    >
+      {loading ? "Generando..." : "Generar imagenes"}
+    </button>
+  );
+}

--- a/frontend/src/components/GeneratedImageGallery.tsx
+++ b/frontend/src/components/GeneratedImageGallery.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import { GeneratedImage } from "@/types/catalog";
+
+type GeneratedImageGalleryProps = {
+  images: GeneratedImage[];
+  onSelect: (image: GeneratedImage) => void;
+};
+
+export function GeneratedImageGallery({ images, onSelect }: GeneratedImageGalleryProps) {
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {images.map((image) => (
+        <figure key={image.cut} className="border rounded p-2">
+          <Image
+            src={image.url}
+            alt={image.cut}
+            width={image.width || 800}
+            height={image.height || 1200}
+            className="w-full h-auto rounded cursor-zoom-in"
+            sizes="(min-width: 768px) 50vw, 100vw"
+            onClick={() => onSelect(image)}
+          />
+          <figcaption className="text-sm mt-1 capitalize">{image.cut}</figcaption>
+        </figure>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ImageModal.tsx
+++ b/frontend/src/components/ImageModal.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import { GeneratedImage } from "@/types/catalog";
+
+type ImageModalProps = {
+  image: GeneratedImage | null;
+  onClose: () => void;
+};
+
+export function ImageModal({ image, onClose }: ImageModalProps) {
+  if (!image) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center" aria-modal="true" role="dialog">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose} />
+      <div className="relative max-w-5xl w-[92vw] md:w-auto p-0" onClick={(event) => event.stopPropagation()}>
+        <button
+          aria-label="Cerrar"
+          className="absolute -top-10 right-0 md:top-2 md:-right-10 bg-white/10 hover:bg-white/20 text-white rounded-full px-3 py-1 text-sm"
+          onClick={onClose}
+          type="button"
+        >
+          ✕
+        </button>
+        <Image
+          src={image.url}
+          alt={image.cut}
+          width={image.width || 1200}
+          height={image.height || 1600}
+          className="rounded shadow-lg max-h-[85vh] w-auto h-auto"
+          sizes="85vh"
+          priority
+        />
+        <div className="mt-2 text-center text-sm text-white/80 capitalize">
+          {image.cut} · Toca fuera para cerrar
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ImageUploadControls.tsx
+++ b/frontend/src/components/ImageUploadControls.tsx
@@ -1,0 +1,78 @@
+import { RefObject } from "react";
+import Image from "next/image";
+import { PreviewImage } from "@/types/catalog";
+
+type ImageUploadControlsProps = {
+  galleryInputRef: RefObject<HTMLInputElement>;
+  cameraInputRef: RefObject<HTMLInputElement>;
+  onFileChange: (files: FileList | null) => void;
+  onOpenGallery: () => void;
+  onOpenCamera: () => void;
+  preview: PreviewImage | null;
+};
+
+export function ImageUploadControls({
+  galleryInputRef,
+  cameraInputRef,
+  onFileChange,
+  onOpenGallery,
+  onOpenCamera,
+  preview,
+}: ImageUploadControlsProps) {
+  return (
+    <div className="space-y-2">
+      <input
+        ref={galleryInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(event) => {
+          onFileChange(event.target.files);
+          event.target.value = "";
+        }}
+      />
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={(event) => {
+          onFileChange(event.target.files);
+          event.target.value = "";
+        }}
+      />
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <button
+          type="button"
+          className="w-full rounded border border-white/20 bg-white/10 px-3 py-2 text-sm text-white hover:bg-white/20"
+          onClick={onOpenGallery}
+        >
+          Elegir foto
+        </button>
+        <button
+          type="button"
+          className="w-full rounded border border-white/20 bg-white/10 px-3 py-2 text-sm text-white hover:bg-white/20 md:hidden"
+          onClick={onOpenCamera}
+        >
+          Tomar foto
+        </button>
+      </div>
+      {preview && (
+        <div className="space-y-2">
+          <div className="text-sm text-white/70">Vista previa</div>
+          <div className="overflow-hidden rounded border border-white/10 bg-black/20">
+            <Image
+              src={preview.url}
+              alt={`Vista previa de ${preview.name}`}
+              width={preview.width || 400}
+              height={preview.height || 400}
+              className="h-auto w-full object-cover"
+              unoptimized
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/LoadingState.tsx
+++ b/frontend/src/components/LoadingState.tsx
@@ -1,0 +1,9 @@
+export function LoadingState() {
+  return (
+    <div className="border rounded p-6 text-neutral-600 space-y-2">
+      <div className="animate-pulse text-white">Inicializando modelo…</div>
+      <div className="animate-pulse text-white">Aplicando textura de tela…</div>
+      <div className="animate-pulse text-white">Renderizando vistas recto y cruzado…</div>
+    </div>
+  );
+}

--- a/frontend/src/components/LogoHeader.tsx
+++ b/frontend/src/components/LogoHeader.tsx
@@ -1,0 +1,15 @@
+import Image from "next/image";
+
+export function LogoHeader() {
+  return (
+    <header className="mb-6 flex items-center justify-between">
+      <Image
+        src="/logo-transparent.webp"
+        alt="Harris & Frank logo"
+        width={180}
+        height={60}
+        priority
+      />
+    </header>
+  );
+}

--- a/frontend/src/hooks/useVirtualStylist.ts
+++ b/frontend/src/hooks/useVirtualStylist.ts
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { fetchCatalog, generateImages } from "@/lib/apiClient";
+import {
+  CatalogResponse,
+  Family,
+  GeneratedImage,
+  PreviewImage,
+} from "@/types/catalog";
+
+const EMPTY_CATALOG: CatalogResponse = { families: [] };
+
+function getDefaultFamily(families: Family[]): Family | undefined {
+  return families.find((family) => family.status === "active") ?? families[0];
+}
+
+export function useVirtualStylist() {
+  const [catalog, setCatalog] = useState<CatalogResponse>(EMPTY_CATALOG);
+  const [familyId, setFamilyId] = useState<string>("");
+  const [colorId, setColorId] = useState<string>("");
+  const [catalogLoading, setCatalogLoading] = useState<boolean>(true);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState<boolean>(false);
+  const [generationError, setGenerationError] = useState<string | null>(null);
+  const [images, setImages] = useState<GeneratedImage[]>([]);
+  const [selectedImage, setSelectedImage] = useState<GeneratedImage | null>(null);
+  const [preview, setPreview] = useState<PreviewImage | null>(null);
+  const previewUrlRef = useRef<string | null>(null);
+  const galleryInputRef = useRef<HTMLInputElement | null>(null);
+  const cameraInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    setCatalogLoading(true);
+    fetchCatalog()
+      .then((data) => {
+        if (!mounted) return;
+        setCatalog(data);
+        const defaultFamily = getDefaultFamily(data.families);
+        if (defaultFamily) {
+          setFamilyId(defaultFamily.family_id);
+          const firstColor = defaultFamily.colors[0];
+          setColorId(firstColor ? firstColor.color_id : "");
+        }
+        setCatalogError(null);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setCatalogError("No se pudo cargar el catálogo");
+      })
+      .finally(() => {
+        if (!mounted) return;
+        setCatalogLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSelectedImage(null);
+      }
+    };
+
+    if (selectedImage) {
+      document.addEventListener("keydown", onKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [selectedImage]);
+
+  const currentFamily = useMemo(
+    () => catalog.families.find((family) => family.family_id === familyId) ?? null,
+    [catalog, familyId],
+  );
+
+  const handleFamilyChange = useCallback(
+    (nextFamilyId: string) => {
+      setFamilyId(nextFamilyId);
+      const nextFamily = catalog.families.find(
+        (family) => family.family_id === nextFamilyId,
+      );
+
+      if (!nextFamily) {
+        setColorId("");
+        return;
+      }
+
+      setColorId((current) => {
+        const hasCurrent = nextFamily.colors.some(
+          (color) => color.color_id === current,
+        );
+        if (hasCurrent) {
+          return current;
+        }
+        const firstColor = nextFamily.colors[0];
+        return firstColor ? firstColor.color_id : "";
+      });
+    },
+    [catalog.families],
+  );
+
+  const handleColorSelect = useCallback((nextColorId: string) => {
+    setColorId(nextColorId);
+  }, []);
+
+  const handleGenerate = useCallback(async () => {
+    if (!familyId || !colorId) {
+      return;
+    }
+
+    setIsGenerating(true);
+    setGenerationError(null);
+    setImages([]);
+
+    try {
+      const { images: generatedImages } = await generateImages({
+        familyId,
+        colorId,
+      });
+      setImages(generatedImages ?? []);
+    } catch (error) {
+      console.error(error);
+      setGenerationError(
+        "No pudimos generar las imágenes. Probemos otra combinación.",
+      );
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [familyId, colorId]);
+
+  const handleFileSelection = useCallback((files: FileList | null) => {
+    const file = files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    previewUrlRef.current = objectUrl;
+
+    const image = new window.Image();
+    image.onload = () => {
+      setPreview({
+        url: objectUrl,
+        name: file.name,
+        width: image.naturalWidth || image.width,
+        height: image.naturalHeight || image.height,
+      });
+    };
+    image.onerror = () => {
+      setPreview({
+        url: objectUrl,
+        name: file.name,
+        width: 400,
+        height: 400,
+      });
+    };
+    image.src = objectUrl;
+  }, []);
+
+  const openGalleryPicker = useCallback(() => {
+    galleryInputRef.current?.click();
+  }, []);
+
+  const openCameraPicker = useCallback(() => {
+    cameraInputRef.current?.click();
+  }, []);
+
+  const openImage = useCallback((image: GeneratedImage) => {
+    setSelectedImage(image);
+  }, []);
+
+  const closeImage = useCallback(() => {
+    setSelectedImage(null);
+  }, []);
+
+  return {
+    catalog,
+    families: catalog.families,
+    catalogLoading,
+    catalogError,
+    familyId,
+    colorId,
+    currentFamily,
+    isGenerating,
+    generationError,
+    images,
+    selectedImage,
+    preview,
+    galleryInputRef,
+    cameraInputRef,
+    selectFamily: handleFamilyChange,
+    selectColor: handleColorSelect,
+    generate: handleGenerate,
+    handleFileSelection,
+    openGalleryPicker,
+    openCameraPicker,
+    openImage,
+    closeImage,
+  };
+}

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,41 @@
+import { API_BASE } from "@/lib/api";
+import { CatalogResponse, GeneratedImage } from "@/types/catalog";
+
+type GenerateRequest = {
+  familyId: string;
+  colorId: string;
+};
+
+type GenerateResponse = {
+  images: GeneratedImage[];
+};
+
+export async function fetchCatalog(): Promise<CatalogResponse> {
+  const response = await fetch(`${API_BASE}/catalog`);
+  if (!response.ok) {
+    throw new Error("Failed to load catalog");
+  }
+  return response.json();
+}
+
+export async function generateImages({
+  familyId,
+  colorId,
+}: GenerateRequest): Promise<GenerateResponse> {
+  const response = await fetch(`${API_BASE}/generate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      family_id: familyId,
+      color_id: colorId,
+      cuts: ["recto", "cruzado"],
+      quality: "final",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to generate images");
+  }
+
+  return response.json();
+}

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -1,0 +1,39 @@
+export type Color = {
+  color_id: string;
+  name: string;
+  hex: string;
+  swatch_url?: string | null;
+};
+
+export type Family = {
+  family_id: string;
+  display_name: string;
+  status: "active" | "inactive";
+  sort: number;
+  colors: Color[];
+};
+
+export type CatalogResponse = {
+  families: Family[];
+};
+
+export type Cut = "recto" | "cruzado";
+
+export type GeneratedImage = {
+  cut: Cut;
+  url: string;
+  width: number;
+  height: number;
+};
+
+export type PreviewImage = {
+  url: string;
+  name: string;
+  width: number;
+  height: number;
+};
+
+export type ColorSelection = {
+  familyId: string;
+  colorId: string;
+};

--- a/frontend/src/types/search.ts
+++ b/frontend/src/types/search.ts
@@ -1,0 +1,5 @@
+import { ColorSelection } from "@/types/catalog";
+
+export type SearchStatus = "idle" | "ok" | "notfound" | "already" | "loading";
+
+export type ResolveTelaResult = ColorSelection | null;


### PR DESCRIPTION
## Summary
- refactor the Home page to orchestrate stateless UI components while delegating side-effects to a new useVirtualStylist hook
- add a thin API client plus shared catalog, image, and search types to keep contracts centralized
- extract reusable presentational components for catalog controls, uploads, loading states, galleries, and modals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d35d48d5f083319845b7644703a37c