### PR TITLE
Add storage adapter abstraction with local fallback

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Backend application package."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,8 +11,9 @@ from pathlib import Path
 app = FastAPI(title="HF Virtual Stylist")
 
 # make sure the folder exists before mounting
-Path("storage").mkdir(parents=True, exist_ok=True)
-app.mount("/files", StaticFiles(directory="storage", html=False), name="files")
+storage_dir = os.getenv("LOCAL_STORAGE_DIR", "storage")
+Path(storage_dir).mkdir(parents=True, exist_ok=True)
+app.mount("/files", StaticFiles(directory=storage_dir, html=False), name="files")
 
 # Errors handler
 add_error_handlers(app)

--- a/backend/app/routers/generate.py
+++ b/backend/app/routers/generate.py
@@ -1,13 +1,11 @@
 from fastapi import APIRouter
 from app.models.generate import GenerationRequest, GenerationResponse
 from app.services.generator import MockGenerator, SdxlTurboGenerator
-from app.services.storage import LocalStorage
 
 
 router = APIRouter()
 USE_MOCK = False
-storage = LocalStorage()  # or R2/S3 later
-generator = MockGenerator(storage) if USE_MOCK else SdxlTurboGenerator(storage)
+generator = MockGenerator() if USE_MOCK else SdxlTurboGenerator()
 
 @router.post("/generate", response_model=GenerationResponse, status_code=201)
 def generate(req: GenerationRequest) -> GenerationResponse:

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,29 +1,75 @@
-# app/services/storage.py
+"""Storage adapter helpers."""
+
 from __future__ import annotations
-from typing import Protocol
-from pathlib import Path
+
 import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Protocol
 
-class Storage(Protocol):
-    def save_bytes(self, data: bytes, key: str, content_type: str = "image/jpeg") -> str: ...
-    def url_for(self, key: str) -> str: ...
 
-class LocalStorage:
-    """
-    Saves files under ./storage and serves them via FastAPI static mount (/files).
-    base_url must match your StaticFiles mount (http://localhost:8000/files by default).
-    """
-    def __init__(self, base_dir: str = "storage", base_url: str = "http://localhost:8000/files"):
-        self.base_dir = Path(base_dir)
-        self.base_url = base_url
+class StorageAdapter(Protocol):
+    """Protocol implemented by storage backends."""
 
     def save_bytes(self, data: bytes, key: str, content_type: str = "image/jpeg") -> str:
-        key = key.lstrip("/\\")
-        dest = self.base_dir / key
+        ...
+
+
+class LocalStorage:
+    """Persist files locally under ``./storage`` and expose them via ``/files``."""
+
+    def __init__(self, base_dir: str, base_url: str):
+        self.base_dir = Path(base_dir)
+        self.base_url = base_url.rstrip("/")
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def save_bytes(self, data: bytes, key: str, content_type: str = "image/jpeg") -> str:
+        safe_key = _normalize_key(key)
+        dest = self.base_dir / safe_key
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(data)
-        return f"{self.base_url}/{key.replace(os.sep, '/')}"
+        return f"{self.base_url}/{safe_key.replace(os.sep, '/')}"
 
-    def url_for(self, key: str) -> str:
-        key = key.lstrip("/\\")
-        return f"{self.base_url}/{key.replace(os.sep, '/')}"
+
+def save_bytes(data: bytes, key: str, content_type: str = "image/jpeg") -> str:
+    """Save *data* using the configured adapter and return a public URL."""
+
+    storage = _get_storage()
+    try:
+        return storage.save_bytes(data, key, content_type=content_type)
+    except Exception as exc:  # pragma: no cover - surfaced by global handler
+        raise RuntimeError("Failed to persist generated file") from exc
+
+
+def _normalize_key(key: str) -> str:
+    # Prevent leading slashes so Path does not treat the key as absolute.
+    return key.lstrip("/\\")
+
+
+@lru_cache(maxsize=1)
+def _get_storage() -> StorageAdapter:
+    driver = os.getenv("STORAGE_DRIVER", "local").lower() or "local"
+    if driver != "local":
+        # Future cloud adapters plug in here; fall back to local for now.
+        driver = "local"
+
+    if driver == "local":
+        return _build_local_storage()
+
+    raise RuntimeError(f"Unsupported storage driver: {driver}")
+
+
+def _build_local_storage() -> LocalStorage:
+    base_dir = os.getenv("LOCAL_STORAGE_DIR", "storage")
+    public_base = os.getenv("PUBLIC_BASE_URL")
+    if public_base:
+        base_url = f"{public_base.rstrip('/')}/files"
+    else:
+        base_url = "http://localhost:8000/files"
+    return LocalStorage(base_dir=base_dir, base_url=base_url)
+
+
+def _reset_storage_cache() -> None:
+    """Testing helper to reset the cached adapter."""
+
+    _get_storage.cache_clear()

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,0 +1,25 @@
+from app.services import storage
+
+
+def test_save_bytes_uses_local_storage(tmp_path, monkeypatch):
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+    monkeypatch.setenv("LOCAL_STORAGE_DIR", str(tmp_path))
+    monkeypatch.setenv("STORAGE_DRIVER", "local")
+    storage._reset_storage_cache()
+
+    url = storage.save_bytes(b"demo", "generated/family/color/image.jpg")
+
+    expected_path = tmp_path / "generated" / "family" / "color" / "image.jpg"
+    assert expected_path.read_bytes() == b"demo"
+    assert url == "http://localhost:8000/files/generated/family/color/image.jpg"
+
+
+def test_save_bytes_respects_public_base_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_STORAGE_DIR", str(tmp_path))
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://api.example.com")
+    monkeypatch.setenv("STORAGE_DRIVER", "local")
+    storage._reset_storage_cache()
+
+    url = storage.save_bytes(b"demo", "generated/family/color/image.jpg")
+
+    assert url == "https://api.example.com/files/generated/family/color/image.jpg"

--- a/backend/tests/test_watermark.py
+++ b/backend/tests/test_watermark.py
@@ -1,15 +1,20 @@
 from pathlib import Path
+
 from app.services.watermark import apply_watermark_image
 
-input_path = Path("test_input.jpg")
-output_path = Path("test_output.jpg")
 
-with open(input_path, "rb") as f:
-    image_bytes = f.read()
+ASSETS_DIR = Path(__file__).parent / "assets"
 
-watermarked = apply_watermark_image(image_bytes, "logo-transparent.webp")
 
-with open(output_path, "wb") as f:
-    f.write(watermarked)
+def test_apply_watermark_image(tmp_path):
+    input_path = ASSETS_DIR / "test_input.jpg"
+    watermark_path = ASSETS_DIR / "logo.webp"
 
-print(f"✅ Watermarked image with PNG logo saved to {output_path}")
+    image_bytes = input_path.read_bytes()
+    watermarked = apply_watermark_image(image_bytes, str(watermark_path))
+
+    output_path = tmp_path / "watermarked.jpg"
+    output_path.write_bytes(watermarked)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add a storage adapter helper that selects a driver from environment variables and defaults to local disk URLs
- update generators and routing to use the shared save_bytes helper while keeping existing API behaviour
- ensure FastAPI static files use the configured directory and add regression tests for storage and watermark utilities

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d440cc8e6c8331a939653823f29578