### PR TITLE
Implement admin database setup and auth helpers

### DIFF
--- a/backend/app/admin/auth.py
+++ b/backend/app/admin/auth.py
@@ -1,0 +1,43 @@
+"""Authentication helpers for the admin API."""
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+from app.core.config import settings
+
+
+_password_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password using passlib."""
+
+    return _password_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify that a plaintext password matches the stored hash."""
+
+    return _password_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(data: Dict[str, Any], expires_delta: Optional[timedelta] = None) -> str:
+    """Create a signed JWT token containing the provided data."""
+
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + (expires_delta or timedelta(hours=1))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+    return encoded_jwt
+
+
+def decode_access_token(token: str) -> Dict[str, Any]:
+    """Decode a JWT token and ensure it is valid."""
+
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    except JWTError as exc:  # pragma: no cover - defensive branch for invalid tokens
+        raise ValueError("Invalid authentication token") from exc
+    return payload

--- a/backend/app/admin/dependencies.py
+++ b/backend/app/admin/dependencies.py
@@ -1,0 +1,47 @@
+"""Reusable FastAPI dependencies for the admin API."""
+from collections.abc import Generator
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from app.admin.auth import decode_access_token
+from app.core.database import SessionLocal
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Yield a database session that is closed after use."""
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def get_current_admin_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> dict:
+    """Validate the JWT from the request Authorization header."""
+
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = credentials.credentials
+    try:
+        payload = decode_access_token(token)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication token",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    return payload

--- a/backend/app/admin/models.py
+++ b/backend/app/admin/models.py
@@ -1,0 +1,40 @@
+"""Database models for the admin application."""
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class FabricFamily(Base):
+    """Represents a fabric family grouping available within the catalog."""
+
+    __tablename__ = "fabric_families"
+
+    id = Column(Integer, primary_key=True, index=True)
+    family_id = Column(String, unique=True, nullable=False, index=True)
+    display_name = Column(String, nullable=False)
+    status = Column(String, nullable=False, default="active")
+
+    colors = relationship(
+        "Color",
+        back_populates="fabric_family",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class Color(Base):
+    """Represents a color option associated with a fabric family."""
+
+    __tablename__ = "colors"
+
+    id = Column(Integer, primary_key=True, index=True)
+    fabric_family_id = Column(
+        Integer, ForeignKey("fabric_families.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    color_id = Column(String, nullable=False, unique=True, index=True)
+    name = Column(String, nullable=False)
+    hex_value = Column(String, nullable=False)
+    swatch_url = Column(String, nullable=True)
+
+    fabric_family = relationship("FabricFamily", back_populates="colors")

--- a/backend/app/admin/schemas.py
+++ b/backend/app/admin/schemas.py
@@ -1,0 +1,49 @@
+"""Pydantic schemas for admin fabric management."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ColorBase(BaseModel):
+    color_id: str
+    name: str
+    hex_value: str
+    swatch_url: Optional[str] = None
+
+
+class ColorCreate(ColorBase):
+    pass
+
+
+class ColorRead(ColorBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FabricBase(BaseModel):
+    family_id: str
+    display_name: str
+    status: str = "active"
+
+
+class FabricCreate(FabricBase):
+    colors: List[ColorCreate] = Field(default_factory=list)
+
+
+class FabricUpdate(BaseModel):
+    family_id: Optional[str] = None
+    display_name: Optional[str] = None
+    status: Optional[str] = None
+    colors: Optional[List[ColorCreate]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class FabricRead(FabricBase):
+    id: int
+    colors: List[ColorRead] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,0 +1,17 @@
+"""Database configuration for SQLAlchemy sessions and models."""
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from app.core.config import settings
+
+
+SQLALCHEMY_DATABASE_URL = settings.database_url
+
+# Create the SQLAlchemy engine that will be used for interacting with the database.
+engine = create_engine(SQLALCHEMY_DATABASE_URL, future=True)
+
+# Configure a session factory that will generate new Session objects for each request.
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+
+# Base class for all ORM models within the project.
+Base = declarative_base()


### PR DESCRIPTION
## Summary
- configure the SQLAlchemy engine, session factory, and declarative base used by the admin service
- add FabricFamily and Color ORM models and the corresponding Pydantic schemas
- implement password hashing/JWT helpers and reusable FastAPI dependencies for database sessions and auth

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `PYTHONPATH=app pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68d47f557e948331be12eb25a0feb02e