### PR TITLE
Improve admin interface responsiveness and styling

### DIFF
--- a/frontend/src/app/admin/AdminTable.tsx
+++ b/frontend/src/app/admin/AdminTable.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import type { FabricRead } from "@/types/admin";
 import { createFabric, deactivateFabric, listFabrics } from "@/lib/adminApi";
@@ -9,90 +8,101 @@ export default function AdminTable({ initialItems }: { initialItems: FabricRead[
   const [items, setItems] = useState<FabricRead[]>(initialItems);
   const [q, setQ] = useState("");
   const [pending, start] = useTransition();
-  const router = useRouter();
-
   async function refresh(query?: string) {
     const data = await listFabrics({ q: query, limit: 50 });
     setItems(data);
   }
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-end gap-3">
-        <div className="flex flex-col">
-          <label className="text-sm">Search</label>
-          <input
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
-            placeholder="family id or name"
-            className="border rounded px-2 py-1"
-          />
+    <div className="space-y-6">
+      <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="flex w-full max-w-sm flex-col gap-1">
+            <label className="text-sm font-medium text-gray-700" htmlFor="admin-search">
+              Search fabrics
+            </label>
+            <div className="flex gap-2">
+              <input
+                id="admin-search"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Family id or name"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm transition focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/20"
+              />
+              <button
+                onClick={() => start(() => refresh(q))}
+                className="whitespace-nowrap rounded-lg bg-black px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black disabled:opacity-60 disabled:hover:bg-black/90 lg:px-5 lg:py-2.5"
+                disabled={pending}
+              >
+                {pending ? "Searching..." : "Search"}
+              </button>
+            </div>
+          </div>
+          <QuickCreate onCreate={() => start(() => refresh(q))} />
         </div>
-        <button
-          onClick={() => start(() => refresh(q))}
-          className="px-3 py-2 rounded bg-black text-white"
-          disabled={pending}
-        >
-          {pending ? "Searching..." : "Search"}
-        </button>
-        <QuickCreate onCreate={() => start(() => refresh(q))} />
       </div>
 
-      <table className="w-full border-collapse">
-        <thead>
-          <tr className="text-left border-b">
-            <th className="py-2 pr-4">Family</th>
-            <th className="py-2 pr-4">ID</th>
-            <th className="py-2 pr-4">Status</th>
-            <th className="py-2 pr-4">Colors</th>
-            <th className="py-2 pr-4">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((f) => (
-            <tr key={f.id} className="border-b">
-              <td className="py-2 pr-4">{f.display_name}</td>
-              <td className="py-2 pr-4">{f.family_id}</td>
-              <td className="py-2 pr-4">
-                <span className={`px-2 py-1 rounded text-sm ${f.status === "active" ? "bg-green-200" : "bg-gray-300"}`}>
-                  {f.status}
-                </span>
-              </td>
-              <td className="py-2 pr-4">
-                <div className="flex gap-2">
-                  {f.colors.map((c) => (
-                    <div key={c.id} className="flex items-center gap-1">
-                      <span className="inline-block w-3 h-3 rounded" style={{ background: c.hex_value }} />
-                      <span className="text-xs text-gray-600">{c.color_id}</span>
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse text-sm sm:text-base">
+            <thead className="bg-gray-50">
+              <tr className="text-left text-gray-600">
+                <th className="px-4 py-3 font-medium">Family</th>
+                <th className="px-4 py-3 font-medium">ID</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 font-medium">Colors</th>
+                <th className="px-4 py-3 font-medium">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((f) => (
+                <tr key={f.id} className="border-t last:border-b-0 hover:bg-gray-50/70">
+                  <td className="px-4 py-3 font-medium text-gray-900">{f.display_name}</td>
+                  <td className="px-4 py-3 text-gray-600">{f.family_id}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold sm:text-sm ${f.status === "active" ? "bg-emerald-100 text-emerald-700" : "bg-gray-200 text-gray-700"}`}
+                    >
+                      {f.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-3">
+                      {f.colors.map((c) => (
+                        <div key={c.id} className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
+                          <span className="inline-block h-3 w-3 rounded-full border border-white shadow" style={{ background: c.hex_value }} />
+                          <span className="font-medium">{c.color_id}</span>
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              </td>
-              <td className="py-2 pr-4">
-                <button
-                  onClick={() =>
-                    start(async () => {
-                      await deactivateFabric(f.id);
-                      await refresh(q);
-                    })
-                  }
-                  disabled={pending || f.status !== "active"}
-                  className="px-3 py-1 rounded bg-black text-white disabled:opacity-50"
-                >
-                  Deactivate
-                </button>
-              </td>
-            </tr>
-          ))}
-          {items.length === 0 && (
-            <tr>
-              <td colSpan={5} className="py-6 text-center text-gray-500">
-                No fabrics found
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      onClick={() =>
+                        start(async () => {
+                          await deactivateFabric(f.id);
+                          await refresh(q);
+                        })
+                      }
+                      disabled={pending || f.status !== "active"}
+                      className="rounded-lg bg-black px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black disabled:cursor-not-allowed disabled:bg-gray-400"
+                    >
+                      Deactivate
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {items.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-sm text-gray-500 sm:text-base">
+                    No fabrics found
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }
@@ -125,23 +135,43 @@ function QuickCreate({ onCreate }: { onCreate: () => void }) {
           onCreate();
         });
       }}
-      className="flex items-end gap-2"
+      className="flex w-full flex-col gap-4 rounded-lg bg-gray-50 p-4 shadow-inner lg:w-auto lg:flex-1 lg:max-w-3xl"
     >
-      <div className="flex flex-col">
-        <label className="text-sm">Display name</label>
-        <input className="border rounded px-2 py-1" value={display} onChange={(e) => setDisplay(e.target.value)} />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-gray-700">Display name</label>
+          <input
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm transition focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/20"
+            value={display}
+            onChange={(e) => setDisplay(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-gray-700">Color name</label>
+          <input
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm transition focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/20"
+            value={colorName}
+            onChange={(e) => setColorName(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-gray-700">Hex</label>
+          <input
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm transition focus:border-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/20"
+            value={hex}
+            onChange={(e) => setHex(e.target.value)}
+          />
+        </div>
+        <div className="flex items-end">
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-black px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black disabled:cursor-not-allowed disabled:bg-gray-400"
+            disabled={pending}
+          >
+            {pending ? "Creating..." : "Quick Create"}
+          </button>
+        </div>
       </div>
-      <div className="flex flex-col">
-        <label className="text-sm">Color name</label>
-        <input className="border rounded px-2 py-1" value={colorName} onChange={(e) => setColorName(e.target.value)} />
-      </div>
-      <div className="flex flex-col">
-        <label className="text-sm">Hex</label>
-        <input className="border rounded px-2 py-1" value={hex} onChange={(e) => setHex(e.target.value)} />
-      </div>
-      <button className="px-3 py-2 rounded bg-black text-white" disabled={pending}>
-        {pending ? "Creating..." : "Quick Create"}
-      </button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the admin search and quick-create controls with focus and hover feedback for better UX
- wrap the fabrics table in a responsive card with improved spacing and pill styling for status and colors
- adapt the layout for small screens with flexible stacking, grids, and horizontal scrolling support

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d48c44583c83318fad9ba48c4571ff