### PR TITLE
Expand project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,76 @@ uvicorn app.main:app --reload --port 8000
 ### Frontend
 npm run dev
 
+---
+
+## Architecture Overview
+
+This repository is organized as a **two-tier application** where a FastAPI backend exposes a REST API that the Next.js frontend consumes. Both services share a simple contract that revolves around catalog metadata and image-generation requests.
+
+- **Frontend (`frontend/`):** A React/Next.js App Router project. UI components live in `src/components`, reusable hooks in `src/hooks`, and all HTTP helpers in `src/lib`. The frontend retrieves catalog metadata, lets the associate curate a request, and sends a JSON payload to `/generate`.
+- **Backend (`backend/`):** A FastAPI application inside `backend/app`. It exposes `/catalog` and `/generate` endpoints, persists generated assets under `backend/storage/`, and serves them via the `/files` static route. Services under `app/services` encapsulate catalog lookups, image synthesis (mock or SDXL), watermarking, and storage.
+- **Shared Contract:** Request/response models in `backend/app/models` (e.g., `GenerationRequest`, `GenerationResponse`) define the JSON schema consumed by the frontend and documented in the backend README.
+
+### Data Flow at a Glance
+
+1. A sales associate selects a fabric family and color from the catalog component, powered by `GET /catalog/fabrics`.
+2. Clicking **Generate** triggers the frontend hook `useVirtualStylist` to POST a `GenerationRequest` to `/generate` with the desired `family_id`, `color_id`, and cuts (poses).
+3. The backend generator service creates (or mocks) images, stores them via `LocalStorage.save_bytes`, and responds with HTTPS URLs under `/files/generated/...` alongside metadata.
+4. The frontend's `GeneratedImageGallery` renders the thumbnails, and `ImageModal` loads the high-resolution assets using the returned URLs.
+
+---
+
+## Environment & Tooling
+
+| Concern | Frontend | Backend |
+| --- | --- | --- |
+| Language | TypeScript (ESNext) | Python 3.10+
+| Package manager | `npm` (Node 18+) | `pip` + `uv`/`venv`
+| Entrypoint | `npm run dev` (Next.js dev server on port 3000) | `uvicorn app.main:app --reload --port 8000`
+| Static assets | `frontend/public` | `/files` mounted from `backend/storage`
+| Tests | `npm run lint` / component tests (future) | `pytest` under `backend/tests`
+
+> Tip: Run both services together for the full experience. The frontend expects the API at `http://localhost:8000` and has CORS rules preconfigured for `http://localhost:3000`.
+
+### Local Development Checklist
+
+1. **Clone & Install:** `npm install` inside `frontend/` and `pip install -r requirements.txt` inside `backend/` (activate the virtualenv as needed).
+2. **Environment Variables:**
+   - Backend honors `APP_VERSION`, `WATERMARK_PATH`, and (future) storage credentials like `AWS_ACCESS_KEY_ID`.
+   - Frontend reads `NEXT_PUBLIC_API_BASE` (defaulting to `http://localhost:8000`).
+3. **Start Services:** Launch the backend first, then the frontend. Use two terminals or a process manager.
+4. **Verify Health:** `curl http://localhost:8000/healthz` should return `{ "ok": true, ... }`. Load `http://localhost:3000` to interact with the UI.
+
+### Deployment Snapshot
+
+- **Backend:** Container-friendly FastAPI app. Mount persistent storage (or configure S3/R2) at `/files`. The provided `deploy.sh` script in the README demonstrates how the team syncs to a RunPod instance.
+- **Frontend:** Ready for Vercel/Netlify deployment. Ensure `NEXT_PUBLIC_API_BASE` points to the deployed backend URL and that CORS allows the frontend origin.
+- **Model Weights:** When switching from the mock generator to SDXL (`USE_MOCK = False` in `app/routers/generate.py`), ensure GPU availability and that the Hugging Face cache is writable (`HF_HOME`).
+
+---
+
+## Feature Walkthrough
+
+### Catalog Exploration
+- `CatalogSelector` fetches fabric families and colors from `/catalog/fabrics`.
+- The UI groups colors by family and highlights availability.
+- Selecting a color updates the hook state and primes the generation request.
+
+### Image Generation
+- `GenerateButton` disables itself while awaiting a response.
+- The backend responds with two `ImageResult` entries (`recto`, `cruzado`), each watermarked via `apply_watermark_image`.
+- URLs are persisted locally by default (`storage/generated/...`) and are immediately available to the frontend.
+
+### Download & Sharing
+- The gallery component provides modal zoom with download-ready URLs.
+- Since assets are served by FastAPI's static files, they can be bookmarked or shared externally as long as the backend remains online.
+
+---
+
+## Troubleshooting
+
+- **CORS errors?** Verify the frontend origin matches the `allow_origins` list in `app/main.py`.
+- **Missing watermark assets?** Set `WATERMARK_PATH` to an accessible `.webp` file (see `backend/tests/assets/logo.webp`).
+- **Slow generation?** When using SDXL, generation speed depends on GPU availability. Switch to the mock generator for demos by setting `USE_MOCK = True` in `app/routers/generate.py`.
+- **Broken image URLs?** Confirm the backend has write permissions to `backend/storage` and that the `/files` mount points to the same directory.
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -74,3 +74,122 @@ Whenever you push from your laptop, on the pod just run:
 curl -s -X POST "https://lnqrev4dnktv7s-8000.proxy.runpod.net/generate" \
   -H "Content-Type: application/json" \
   -d '{"family_id":"lana-normal","color_id":"green-001","cuts":["recto"]}'
+
+---
+
+## Service Blueprint
+
+### Project Layout
+
+```
+backend/
+├── app/
+│   ├── main.py                # FastAPI app factory & CORS/static config
+│   ├── routers/               # HTTP routers (catalog, generate, admin)
+│   ├── models/                # Pydantic request/response contracts
+│   ├── services/              # Catalog lookup, storage, generator, watermark
+│   ├── core/                  # Settings, database, logging primitives
+│   └── admin/                 # Admin fabric management endpoints
+├── tests/                     # pytest suite and fixtures
+├── requirements.txt           # Runtime dependencies
+└── seed.py                    # Example data seeding script
+```
+
+### Runtime Flow
+
+1. **Request:** The frontend submits a `POST /generate` payload shaped like `GenerationRequest` (see below).
+2. **Routing:** `app/routers/generate.py` picks the generator implementation (`MockGenerator` by default) and delegates the call.
+3. **Generation:**
+   - `MockGenerator` creates placeholder JPEGs and watermarks them.
+   - `SdxlTurboGenerator` lazily loads `StableDiffusionXLPipeline`, runs inference, applies a watermark, and returns metadata including seeds and inference timing.
+4. **Storage:** `LocalStorage.save_bytes` (configurable) writes to `storage/generated/...` and returns a URL served under `/files`.
+5. **Response:** The endpoint returns a `GenerationResponse` with IDs, duration, and URLs. Errors propagate through `app/errors.py`, which maps exceptions to JSON responses.
+
+Static assets are mounted through `FastAPIStaticFiles` in `app/main.py`, making every generated file available as soon as it is written.
+
+---
+
+## API Contracts
+
+### `POST /generate`
+
+```jsonc
+{
+  "family_id": "lana-normal",        // required: fabric collection code
+  "color_id": "green-001",           // required: color variant id
+  "cuts": ["recto", "cruzado"],      // optional: defaults to both poses
+  "quality": "preview",              // optional: influences inference params
+  "seed": 123456789                   // optional: deterministic generation
+}
+```
+
+Response (`201 Created`):
+
+```jsonc
+{
+  "request_id": "a1b2c3d4e5",
+  "status": "completed",
+  "duration_ms": 42857,
+  "images": [
+    {
+      "cut": "recto",
+      "url": "http://localhost:8000/files/generated/.../recto.jpg",
+      "width": 1024,
+      "height": 1536,
+      "watermark": true,
+      "meta": {
+        "seed": "123456789",
+        "steps": "28",
+        "guidance": "5.5",
+        "engine": "sdxl-base"
+      }
+    }
+  ],
+  "meta": {
+    "family_id": "lana-normal",
+    "color_id": "green-001",
+    "device": "cuda"
+  }
+}
+```
+
+### `GET /catalog/fabrics`
+
+Returns the structured catalog consumed by the UI, sourced from `app/services/catalog.py`. Each fabric family includes a list of colors and metadata describing seasonality, swatch URLs, and availability flags.
+
+### `GET /healthz`
+
+Lightweight heartbeat endpoint that returns `{ "ok": true, "version": "…" }`. Useful for load balancer checks and local validation.
+
+---
+
+## Configuration & Environment Variables
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `APP_VERSION` | Exposed via `/healthz` for release tracking. | `0.1.0` |
+| `WATERMARK_PATH` | Path to the watermark image consumed by `apply_watermark_image`. | `tests/assets/logo.webp` |
+| `HF_HOME` | Hugging Face cache location for SDXL weights. | `$HOME/.cache/huggingface` |
+| `HF_HUB_ENABLE_HF_TRANSFER` | Enables accelerated downloads when set to `1`. | unset |
+| `USE_MOCK` | Toggle between mock generator and SDXL. Set in `routers/generate.py`. | `False` |
+
+> For cloud storage, implement a new `Storage` subclass (e.g., S3) and inject it into `SdxlTurboGenerator` in `routers/generate.py`.
+
+---
+
+## Testing & Quality Gates
+
+- `pytest -q` exercises unit tests under `backend/tests`, including watermarking and API contract validations.
+- `curl` commands listed above are ideal for manual smoke testing or scripting.
+- To profile SDXL inference, export `HF_HOME` and monitor logs emitted by `SdxlTurboGenerator` (seed, duration, device).
+
+---
+
+## Extending the Backend
+
+1. **Add a new endpoint:** Create a module in `app/routers`, wire it in `app/main.py`, and document the schema under `app/models`.
+2. **Swap storage providers:** Implement `Storage.save_bytes` and `Storage.save_file` interfaces (see `app/services/storage.py`). Update the router to use the new provider.
+3. **Customize prompts:** Modify `base_prompt` and `prompts` within `SdxlTurboGenerator`. Keep the negative prompt aligned with brand guidelines.
+4. **Persist metadata:** Integrate a database by leveraging `app/core/database.py` and `alembic/` migrations to store run history or catalog state.
+
+These conventions keep the backend modular while allowing rapid experimentation with new AI models or delivery pipelines.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,3 +41,63 @@ uvicorn app.main:app --reload --port 8000
 
 <!-- Start frontend -->
 npm run dev
+
+---
+
+## Application Guide
+
+### Folder Structure
+
+```
+frontend/
+├── src/
+│   ├── app/                # App Router entrypoints (layout, page, globals.css)
+│   ├── components/         # Reusable UI building blocks
+│   ├── hooks/              # State + API orchestration (`useVirtualStylist`)
+│   ├── lib/                # REST client (`apiClient`), typed endpoints
+│   └── types/              # Shared TypeScript interfaces
+├── public/                 # Static assets (logos, icons)
+├── next.config.ts          # Custom Next.js config (images, rewrites, etc.)
+└── tsconfig.json           # Path aliases and compiler options
+```
+
+### Core Experience
+
+1. **Catalog Discovery** – `CatalogSelector` renders families and colors fetched from `GET /catalog/fabrics`. Selections are bubbled up through props into the main page state.
+2. **Styling Workflow** – `SearchTela` combines the selector, upload controls, and copy deck to guide the associate through fabric exploration.
+3. **Generation Trigger** – `GenerateButton` invokes the `useVirtualStylist` hook, which wraps the API call, loading states, and error handling.
+4. **Results Gallery** – `GeneratedImageGallery` and `ImageModal` display returned assets, providing zoom/download actions using the URLs served by FastAPI.
+
+### API Integration Details
+
+- `src/lib/apiClient.ts` centralizes fetch logic. It respects the `NEXT_PUBLIC_API_BASE` environment variable and automatically attaches JSON headers.
+- `src/lib/api.ts` and `src/lib/adminApi.ts` expose typed helpers such as `generateLook()` or `fetchCatalog()` to keep components declarative.
+- The hook `useVirtualStylist` manages debounce, optimistic loading, and exposes `generate`, `isLoading`, and `result` fields for the UI.
+
+### Styling System
+
+- Tailwind CSS powers utility classes (see `postcss.config.mjs` and `globals.css`).
+- Component-level styling leans on semantic classnames with Tailwind modifiers, ensuring the layout remains responsive on showroom tablets.
+- Add bespoke design tokens inside `globals.css` (CSS variables) for brand colors and typography.
+
+### Environment Variables
+
+Create a `.env.local` with:
+
+```
+NEXT_PUBLIC_API_BASE=http://localhost:8000
+```
+
+For production, point this variable to the deployed FastAPI origin and ensure CORS allows the frontend hostname.
+
+### Development Tips
+
+- Run `npm run lint` to catch JSX/TypeScript issues early.
+- Use the React DevTools extension to inspect component state transitions, especially around `useVirtualStylist`.
+- When mocking the backend, you can stub responses in `apiClient.ts` or leverage MSW (Mock Service Worker) in future tests.
+
+### Deployment Notes
+
+- Vercel automatically reads environment variables prefixed with `NEXT_PUBLIC_` from the project dashboard.
+- To host elsewhere, generate a static build with `npm run build` and run `npm start` behind your preferred reverse proxy.
+- Ensure the backend exposes HTTPS URLs for generated images so that modern browsers do not block mixed content.


### PR DESCRIPTION
## Summary
- expand the root README with architecture, workflow, and troubleshooting details
- document backend layout, API contracts, configuration, and extension guidance
- augment the frontend README with structure, integration notes, and deployment tips

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d609b4fc848331bffaa05efddb15a4