### PR TITLE
docs: refresh project readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,134 +1,67 @@
-# The HF Virtual Stylist
+# HF Virtual Stylist
 
-An AI-powered design studio that brings the entire Harris & Frank bespoke collection to life, instantly.
+The HF Virtual Stylist pairs a FastAPI backend with a Next.js front end to let Harris & Frank sales associates design bespoke looks in real time. The system generates SDXL-powered suit renders, manages a structured fabric catalog, and exposes an admin surface for merchandising teams to curate offerings.
 
----
+## Feature Highlights
+- **Photorealistic generation pipeline** – The backend orchestrates Stable Diffusion XL with optional ControlNet and IP-Adapter guidance while watermarking and persisting each render. Local disk storage works out of the box and a Cloudflare R2 backend can be switched on via environment variables.【F:backend/app/services/generator.py†L1-L117】【F:backend/app/services/storage.py†L1-L60】
+- **Dynamic catalog management** – Fabric families and colors live in a SQLAlchemy database, can be seeded from `app/data/fabrics.json`, and are exposed both to the public catalog endpoint and to an internal admin API used by the dashboard in `/admin`. Alembic migrations keep the schema in sync.【F:backend/app/routers/catalog.py†L1-L55】【F:backend/alembic/versions/41832a8aee86_add_fabric_and_color_models.py†L1-L46】【F:backend/seed.py†L1-L66】
+- **Sales-floor friendly UI** – The Next.js App Router client offers guided fabric selection, live previews, and a modal gallery for generated imagery. It also ships with an admin table that can search, toggle, and create fabric entries against the FastAPI admin routes.【F:frontend/src/app/page.tsx†L1-L70】【F:frontend/src/app/admin/AdminTable.tsx†L1-L228】
+- **RunPod-ready deployment** – `backend/devops/runpod/deploy.sh` installs dependencies on GPU pods, wires up ControlNet/IP-Adapter assets, applies migrations, seeds data, and starts the API—mirroring the production pipeline.【F:backend/devops/runpod/deploy.sh†L1-L134】
 
-## The Vision
+## Repository Layout
+| Path | Description |
+| --- | --- |
+| `backend/` | FastAPI service, SQLAlchemy models, SDXL generation, Alembic migrations, and deployment tooling. |
+| `frontend/` | Next.js 15 App Router project with the client experience and admin dashboard. |
 
-In the world of bespoke tailoring, imagination is the only limit. Yet, showrooms are finite. **Project Atelier** bridges the gap between a client's vision and tangible reality by creating an infinite digital showroom.
+## Local Setup
+### Prerequisites
+- Python 3.11
+- Node.js 18+ and npm
+- SQLite (or another database supported by SQLAlchemy) for local development
 
-This tool empowers Harris & Frank's sales associates to move beyond physical samples and render any suit from their catalog in any available fabric and color combination, on-demand. It transforms the sales conversation into an interactive design session, providing clients with immediate, photorealistic visualizations of their unique creations.
-
----
-
-## How It Works
-
-The workflow is designed for elegance and speed, mirroring a natural sales conversation:
-
-1.  **Select a Style:** The associate chooses a fabric family or style that matches the client's needs (e.g., "Lana-Cachemir").
-
-2.  **Choose a Color:** The UI displays a rich palette of available colors for that specific fabric.
-
-3.  **Generate Reality:** With a single click, the AI engine generates two photorealistic, high-resolution images of the final suit, showcasing both a direct (`recto`) and crossed-arm (`cruzado`) pose.
-
----
-
-## Key Features
-
--   **Dynamic Fabric & Color Catalog:** A fully dynamic, visually-driven menu of all available H&F fabrics and colors, easily managed via a dedicated admin panel.
--   **Photorealistic On-Demand Renders:** State-of-the-art AI generates lifelike images in under 60 seconds, capturing the unique texture and drape of each fabric.
--   **Seamless Sharing:** Associates can instantly share the generated visuals with clients via a public link, continuing the sales conversation beyond the showroom.
--   **Built for the Sales Floor:** A clean, intuitive, and reliable interface designed for tablets and large screens in a client-facing environment.
-
----
-
-## Tech Stack
-
-This project leverages a modern, high-performance stack to deliver a cutting-edge experience.
-
--   **Frontend:** Next.js, React, Tailwind CSS
--   **Backend:** FastAPI, Python
--   **AI Engine:** PyTorch, SDXL, with custom-trained LoRA models for fabric realism and ControlNet for pose consistency.
-
----
-
-## Current Status
-
-**MVP in Development.** The backend skeleton with mock data is complete and functional. The minimal frontend UI is in progress. The core focus is on completing the Week 1 deliverable: a functional end-to-end flow with placeholder data.
-
----
-
-## Commands
 ### Backend
-source .venv/Scripts/activate
-
-uvicorn app.main:app --reload --port 8000
-
+1. Create `backend/.env` with at least:
+   ```env
+   database_url=sqlite:///./storage/app.db
+   admin_password=change-me
+   jwt_secret=local-dev-secret
+   jwt_algorithm=HS256
+   storage_backend=local
+   public_base_url=http://localhost:8000/files
+   # R2 credentials only when using storage_backend=r2
+   # r2_account_id=...
+   # r2_access_key_id=...
+   # r2_secret_access_key=...
+   # r2_bucket_name=...
+   # r2_public_url=https://<bucket>.r2.dev
+   ```
+2. (Optional) Create and activate a virtual environment.
+3. Install dependencies: `pip install -r backend/requirements.txt`.
+4. Apply migrations from `backend/`: `alembic upgrade head`.
+5. Populate fabrics from the bundled data (optional): `python seed.py`.
+6. Start the API: `uvicorn app.main:app --reload --port 8000`.
 
 ### Frontend
-npm run dev
+1. Install dependencies from `frontend/`: `npm install`.
+2. Create `frontend/.env.local` and point the proxy and admin page to your API:
+   ```env
+   NEXT_PUBLIC_RUNPOD_URL=http://localhost:8000
+   NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+   ```
+   The Next.js config rewrites `/api/*` calls to `NEXT_PUBLIC_RUNPOD_URL`, so the catalog and generation hooks work both locally and on RunPod.【F:frontend/next.config.ts†L1-L21】【F:frontend/src/lib/apiClient.ts†L1-L38】
+3. Start the dev server: `npm run dev` (defaults to port 3000).
 
----
+Visit `http://localhost:3000` for the stylist UI and `http://localhost:3000/admin` for the merchandising console.
 
-## Architecture Overview
+## Testing
+- Backend: `pytest -q`
+- Frontend: `npm run lint`
 
-This repository is organized as a **two-tier application** where a FastAPI backend exposes a REST API that the Next.js frontend consumes. Both services share a simple contract that revolves around catalog metadata and image-generation requests.
+## Deployment Notes
+- Use `backend/devops/runpod/deploy.sh` on RunPod to clone the repo, install Python packages, configure ControlNet/IP-Adapter assets, run migrations, seed data, and launch Uvicorn.【F:backend/devops/runpod/deploy.sh†L1-L134】
+- Switch to Cloudflare R2 storage by setting `storage_backend=r2` and providing the R2 credentials in `.env`; URLs are rewritten automatically when `public_base_url` is absent.【F:backend/app/routers/generate.py†L1-L40】【F:backend/app/services/storage.py†L26-L60】
 
-- **Frontend (`frontend/`):** A React/Next.js App Router project. UI components live in `src/components`, reusable hooks in `src/hooks`, and all HTTP helpers in `src/lib`. The frontend retrieves catalog metadata, lets the associate curate a request, and sends a JSON payload to `/generate`.
-- **Backend (`backend/`):** A FastAPI application inside `backend/app`. It exposes `/catalog` and `/generate` endpoints, persists generated assets under `backend/storage/`, and serves them via the `/files` static route. Services under `app/services` encapsulate catalog lookups, image synthesis (mock or SDXL), watermarking, and storage.
-- **Shared Contract:** Request/response models in `backend/app/models` (e.g., `GenerationRequest`, `GenerationResponse`) define the JSON schema consumed by the frontend and documented in the backend README.
-
-### Data Flow at a Glance
-
-1. A sales associate selects a fabric family and color from the catalog component, powered by `GET /catalog/fabrics`.
-2. Clicking **Generate** triggers the frontend hook `useVirtualStylist` to POST a `GenerationRequest` to `/generate` with the desired `family_id`, `color_id`, and cuts (poses).
-3. The backend generator service creates (or mocks) images, stores them via `LocalStorage.save_bytes`, and responds with HTTPS URLs under `/files/generated/...` alongside metadata.
-4. The frontend's `GeneratedImageGallery` renders the thumbnails, and `ImageModal` loads the high-resolution assets using the returned URLs.
-
----
-
-## Environment & Tooling
-
-| Concern | Frontend | Backend |
-| --- | --- | --- |
-| Language | TypeScript (ESNext) | Python 3.10+
-| Package manager | `npm` (Node 18+) | `pip` + `uv`/`venv`
-| Entrypoint | `npm run dev` (Next.js dev server on port 3000) | `uvicorn app.main:app --reload --port 8000`
-| Static assets | `frontend/public` | `/files` mounted from `backend/storage`
-| Tests | `npm run lint` / component tests (future) | `pytest` under `backend/tests`
-
-> Tip: Run both services together for the full experience. The frontend expects the API at `http://localhost:8000` and has CORS rules preconfigured for `http://localhost:3000`.
-
-### Local Development Checklist
-
-1. **Clone & Install:** `npm install` inside `frontend/` and `pip install -r requirements.txt` inside `backend/` (activate the virtualenv as needed).
-2. **Environment Variables:**
-   - Backend honors `APP_VERSION`, `WATERMARK_PATH`, and (future) storage credentials like `AWS_ACCESS_KEY_ID`.
-   - Frontend reads `NEXT_PUBLIC_API_BASE` (defaulting to `http://localhost:8000`).
-3. **Start Services:** Launch the backend first, then the frontend. Use two terminals or a process manager.
-4. **Verify Health:** `curl http://localhost:8000/healthz` should return `{ "ok": true, ... }`. Load `http://localhost:3000` to interact with the UI.
-
-### Deployment Snapshot
-
-- **Backend:** Container-friendly FastAPI app. Mount persistent storage (or configure S3/R2) at `/files`. The provided `deploy.sh` script in the README demonstrates how the team syncs to a RunPod instance.
-- **Frontend:** Ready for Vercel/Netlify deployment. Ensure `NEXT_PUBLIC_API_BASE` points to the deployed backend URL and that CORS allows the frontend origin.
-- **Model Weights:** When switching from the mock generator to SDXL (`USE_MOCK = False` in `app/routers/generate.py`), ensure GPU availability and that the Hugging Face cache is writable (`HF_HOME`).
-
----
-
-## Feature Walkthrough
-
-### Catalog Exploration
-- `CatalogSelector` fetches fabric families and colors from `/catalog/fabrics`.
-- The UI groups colors by family and highlights availability.
-- Selecting a color updates the hook state and primes the generation request.
-
-### Image Generation
-- `GenerateButton` disables itself while awaiting a response.
-- The backend responds with two `ImageResult` entries (`recto`, `cruzado`), each watermarked via `apply_watermark_image`.
-- URLs are persisted locally by default (`storage/generated/...`) and are immediately available to the frontend.
-
-### Download & Sharing
-- The gallery component provides modal zoom with download-ready URLs.
-- Since assets are served by FastAPI's static files, they can be bookmarked or shared externally as long as the backend remains online.
-
----
-
-## Troubleshooting
-
-- **CORS errors?** Verify the frontend origin matches the `allow_origins` list in `app/main.py`.
-- **Missing watermark assets?** Set `WATERMARK_PATH` to an accessible `.webp` file (see `backend/tests/assets/logo.webp`).
-- **Slow generation?** When using SDXL, generation speed depends on GPU availability. Switch to the mock generator for demos by setting `USE_MOCK = True` in `app/routers/generate.py`.
-- **Broken image URLs?** Confirm the backend has write permissions to `backend/storage` and that the `/files` mount points to the same directory.
-
+## Additional Documentation
+- [`backend/README.md`](backend/README.md) – detailed API contracts, environment variables, and generator internals.
+- [`frontend/README.md`](frontend/README.md) – Next.js architecture and admin console details.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,217 +1,62 @@
-# Start image creation
-  curl -s -X POST http://127.0.0.1:8000/generate \
-  -H "Content-Type: application/json" \
-  -d '{"family_id":"lana-normal","color_id":"green-001", "cuts":["recto","cruzado"]}'
+# Backend – FastAPI & SDXL Service
 
-    curl -s -X POST http://127.0.0.1:8000/generate \
-  -H "Content-Type: application/json" \
-  -d '{"family_id":"lana-cachemir","color_id":"navy-001", "cuts":["cruzado"]}'
+## Overview
+The backend powers catalog management, admin tooling, and SDXL image synthesis. It exposes REST endpoints for the public stylist UI as well as protected admin routes. Image generation defaults to the `SdxlTurboGenerator`, which supports optional ControlNet and IP-Adapter guidance while watermarking every render before it is stored.【F:backend/app/services/generator.py†L1-L117】
 
-    curl -s -X POST http://127.0.0.1:8000/generate \
-  -H "Content-Type: application/json" \
-  -d '{"family_id":"algodon-tech","color_id":"negro-001", "cuts":["recto"]}'
+## Environment Configuration
+Create `backend/.env` before starting the service. Required keys mirror `app/core/config.py` and the storage adapters.【F:backend/app/core/config.py†L1-L31】【F:backend/app/services/storage.py†L1-L60】
 
-## Fixed seed
-curl -s -X POST http://127.0.0.1:8000/generate \
-  -H "Content-Type: application/json" \
-  -d '{"family_id":"algodon-tech","color_id":"negro-001","cuts":["recto"],"seed":123456789}'
-
-  curl -s -X POST http://127.0.0.1:8000/generate \
-  -H "Content-Type: application/json" \
-  -d '{"family_id":"algodon-tech","color_id":"negro-001","cuts":["cruzado"],"seed":123456789}'
-
-
-## extract recto
-jq -r '.images[0].url' out.json | sed 's|^data:image/png;base64,||' | base64 -d > recto.png
-## extract cruzado
-jq -r '.images[1].url' out.json | sed 's|^data:image/png;base64,||' | base64 -d > cruzado.png
-
-
-<!-- TESTS -->
-
-## Testing in general
-pytest -q
-
-### Health
-curl -s http://127.0.0.1:8000/healthz
-
-Expect: {"ok":true,...}
-
-### Generate
-curl -s -X POST http://127.0.0.1:8000/generate \
-  -H "Content-Type: application/json" \
-  -d '{"family_id":"lana-normal","color_id":"green-001"}'
-
-Expect: images[0].url and images[1].url HTTP URLs under /files/generated/...
-
-- URLs load (HEAD check)
-```
-URL1="<<paste images[0].url>>"
-URL2="<<paste images[1].url>>"
-curl -I "$URL1"
-curl -I "$URL2"
-```
-
-
-
-<!-- Run backend -->
-uvicorn app.main:app --reload --port 8000
-
-
-
-
-
-## POD
-### Sync POD - One command
-Created a quick deploy script in the pod so syncing is one command:
-
-cat > /workspace/deploy.sh <<'SH'
-set -e
-cd /workspace/app
-export PYTHONUNBUFFERED=1
-git fetch origin
-git reset --hard origin/main
-cd backend
-pip install -r requirements.txt -q
-export PYTHONPATH=/workspace/app/backend
-export HF_HOME=/workspace/.cache/huggingface
-export HF_HUB_ENABLE_HF_TRANSFER=1
-export WATERMARK_PATH=/workspace/app/backend/tests/assets/watermark-logo.png
-python - <<'PY'
-import torch, torchvision
-print("[sanity] torch", torch.__version__, "torchvision", torchvision.__version__)
-from transformers import CLIPImageProcessor; print("[sanity] CLIPImageProcessor OK")
-from diffusers import StableDiffusionXLPipeline; print("[sanity] SDXL pipeline import OK")
-PY
-pkill -f uvicorn || true
-uvicorn app.main:app --host 0.0.0.0 --port 8000
-SH
-chmod +x /workspace/deploy.sh
-
-
-Whenever you push from your laptop, on the pod just run:
-
-/workspace/deploy.sh
-
-
-### Testing Pod
-curl -s -X POST "https://lnqrev4dnktv7s-8000.proxy.runpod.net/generate" \
-  -H "Content-Type: application/json" \
-  -d '{"family_id":"lana-normal","color_id":"green-001","cuts":["recto"]}'
-
----
-
-## Service Blueprint
-
-### Project Layout
-
-```
-backend/
-├── app/
-│   ├── main.py                # FastAPI app factory & CORS/static config
-│   ├── routers/               # HTTP routers (catalog, generate, admin)
-│   ├── models/                # Pydantic request/response contracts
-│   ├── services/              # Catalog lookup, storage, generator, watermark
-│   ├── core/                  # Settings, database, logging primitives
-│   └── admin/                 # Admin fabric management endpoints
-├── tests/                     # pytest suite and fixtures
-├── requirements.txt           # Runtime dependencies
-└── seed.py                    # Example data seeding script
-```
-
-### Runtime Flow
-
-1. **Request:** The frontend submits a `POST /generate` payload shaped like `GenerationRequest` (see below).
-2. **Routing:** `app/routers/generate.py` picks the generator implementation (`MockGenerator` by default) and delegates the call.
-3. **Generation:**
-   - `MockGenerator` creates placeholder JPEGs and watermarks them.
-   - `SdxlTurboGenerator` lazily loads `StableDiffusionXLPipeline`, runs inference, applies a watermark, and returns metadata including seeds and inference timing.
-4. **Storage:** `LocalStorage.save_bytes` (configurable) writes to `storage/generated/...` and returns a URL served under `/files`.
-5. **Response:** The endpoint returns a `GenerationResponse` with IDs, duration, and URLs. Errors propagate through `app/errors.py`, which maps exceptions to JSON responses.
-
-Static assets are mounted through `FastAPIStaticFiles` in `app/main.py`, making every generated file available as soon as it is written.
-
----
-
-## API Contracts
-
-### `POST /generate`
-
-```jsonc
-{
-  "family_id": "lana-normal",        // required: fabric collection code
-  "color_id": "green-001",           // required: color variant id
-  "cuts": ["recto", "cruzado"],      // optional: defaults to both poses
-  "quality": "preview",              // optional: influences inference params
-  "seed": 123456789                   // optional: deterministic generation
-}
-```
-
-Response (`201 Created`):
-
-```jsonc
-{
-  "request_id": "a1b2c3d4e5",
-  "status": "completed",
-  "duration_ms": 42857,
-  "images": [
-    {
-      "cut": "recto",
-      "url": "http://localhost:8000/files/generated/.../recto.jpg",
-      "width": 1024,
-      "height": 1536,
-      "watermark": true,
-      "meta": {
-        "seed": "123456789",
-        "steps": "28",
-        "guidance": "5.5",
-        "engine": "sdxl-base"
-      }
-    }
-  ],
-  "meta": {
-    "family_id": "lana-normal",
-    "color_id": "green-001",
-    "device": "cuda"
-  }
-}
-```
-
-### `GET /catalog/fabrics`
-
-Returns the structured catalog consumed by the UI, sourced from `app/services/catalog.py`. Each fabric family includes a list of colors and metadata describing seasonality, swatch URLs, and availability flags.
-
-### `GET /healthz`
-
-Lightweight heartbeat endpoint that returns `{ "ok": true, "version": "…" }`. Useful for load balancer checks and local validation.
-
----
-
-## Configuration & Environment Variables
-
-| Variable | Purpose | Default |
+| Key | Purpose | Example |
 | --- | --- | --- |
-| `APP_VERSION` | Exposed via `/healthz` for release tracking. | `0.1.0` |
-| `WATERMARK_PATH` | Path to the watermark image consumed by `apply_watermark_image`. | `tests/assets/watermark-logo.png` |
-| `HF_HOME` | Hugging Face cache location for SDXL weights. | `$HOME/.cache/huggingface` |
-| `HF_HUB_ENABLE_HF_TRANSFER` | Enables accelerated downloads when set to `1`. | unset |
-| `USE_MOCK` | Toggle between mock generator and SDXL. Set in `routers/generate.py`. | `False` |
+| `database_url` | SQLAlchemy connection string. | `sqlite:///./storage/app.db` |
+| `admin_password` | Seed credential for admin flows (hash or plain, depending on usage). | `change-me` |
+| `jwt_secret` / `jwt_algorithm` | JWT signing secrets for admin endpoints. | `local-secret` / `HS256` |
+| `storage_backend` | `local` (default) or `r2`. | `local` |
+| `public_base_url` | Optional absolute base used when rewriting local storage URLs. | `http://localhost:8000/files` |
+| `r2_*` keys | Cloudflare R2 credentials when `storage_backend=r2`. | _see `.env`_ |
+| `HF_HOME`, `WATERMARK_PATH`, `CONTROLNET_*`, `IP_ADAPTER_*` | Advanced generation toggles read directly inside the generator module. | _optional_ |
 
-> For cloud storage, implement a new `Storage` subclass (e.g., S3) and inject it into `SdxlTurboGenerator` in `routers/generate.py`.
+## Installation & Setup
+1. (Optional) Create a Python 3.11 virtual environment.
+2. Install dependencies from the repo root: `pip install -r backend/requirements.txt`.
+3. Ensure the storage directory exists (`backend/storage/` is created automatically when the app boots).【F:backend/app/main.py†L1-L33】
 
----
+### Database & Migrations
+1. Configure the Alembic connection in `.env` (the CLI reads `database_url`).
+2. Apply the latest schema: `alembic upgrade head`. The initial migration creates the `fabric_families` and `colors` tables used by both the catalog and admin experiences.【F:backend/alembic/versions/41832a8aee86_add_fabric_and_color_models.py†L1-L46】
+3. Seed fabric data and swatch URLs (optional): `python seed.py`. The script ingests `app/data/fabrics.json` and enriches swatches from `app/data/swatch_mapping.csv`.【F:backend/seed.py†L1-L66】
 
-## Testing & Quality Gates
+### Running the API
+Launch the development server from `backend/`:
+```bash
+uvicorn app.main:app --reload --port 8000
+```
+This mounts generated assets under `/files`, enables CORS for the Next.js dev server, and registers the catalog, generate, and admin routers.【F:backend/app/main.py†L1-L35】
 
-- `pytest -q` exercises unit tests under `backend/tests`, including watermarking and API contract validations.
-- `curl` commands listed above are ideal for manual smoke testing or scripting.
-- To profile SDXL inference, export `HF_HOME` and monitor logs emitted by `SdxlTurboGenerator` (seed, duration, device).
+## Storage Backends
+- **LocalStorage** – Saves images under `storage/` and rewrites URLs to `/files/...`. Ideal for local workstations or single-node deployments.【F:backend/app/services/storage.py†L16-L38】
+- **R2Storage** – Uploads to Cloudflare R2 using S3-compatible credentials and returns the public CDN URL. Enable it by setting `storage_backend=r2` and supplying the R2 keys in `.env`.【F:backend/app/services/storage.py†L40-L60】
 
----
+## Generation Pipeline
+- `SdxlTurboGenerator` performs text-to-image using Stable Diffusion XL, optional refiner steps, ControlNet, and IP-Adapter prompts controlled through environment variables. Outputs are watermarked before storage.【F:backend/app/services/generator.py†L55-L188】
+- `MockGenerator` can be toggled by setting `USE_MOCK = True` inside `app/routers/generate.py` for lightweight demos that still exercise watermarking and storage flows.【F:backend/app/services/generator.py†L43-L85】【F:backend/app/routers/generate.py†L1-L40】
 
-## Extending the Backend
+## API Reference
+| Method & Path | Description |
+| --- | --- |
+| `GET /healthz` | Returns `{ "ok": true, "version": ... }` for health checks.【F:backend/app/main.py†L27-L33】 |
+| `GET /catalog` | Loads active fabric families and colors from the database, merging extra metadata from `app/data/fabrics.json`.【F:backend/app/routers/catalog.py†L1-L55】 |
+| `POST /generate` | Accepts a `GenerationRequest` (`family_id`, `color_id`, optional `cuts`, `seed`, `quality`) and returns URLs plus metadata for each generated cut. Local storage URLs are rewritten to absolute URLs when necessary.【F:backend/app/models/generate.py†L1-L24】【F:backend/app/routers/generate.py†L24-L40】 |
+| `GET /admin/fabrics` | Lists fabric families with pagination, search, and status filters for the admin dashboard.【F:backend/app/admin/router.py†L1-L34】 |
+| `POST /admin/fabrics` | Creates a fabric family with optional color definitions (deduplication is enforced at the DB level).【F:backend/app/admin/router.py†L36-L61】 |
+| `PATCH /admin/fabrics/{fabric_id}` | Updates identifiers, display names, status, and replaces associated colors in one call.【F:backend/app/admin/router.py†L63-L95】 |
+| `POST /admin/fabrics/{fabric_id}/deactivate` | Convenience endpoint to mark a fabric family as inactive without editing other fields.【F:backend/app/admin/router.py†L97-L111】 |
 
-1. **Add a new endpoint:** Create a module in `app/routers`, wire it in `app/main.py`, and document the schema under `app/models`.
-2. **Swap storage providers:** Implement `Storage.save_bytes` and `Storage.save_file` interfaces (see `app/services/storage.py`). Update the router to use the new provider.
-3. **Customize prompts:** Modify `base_prompt` and `prompts` within `SdxlTurboGenerator`. Keep the negative prompt aligned with brand guidelines.
-4. **Persist metadata:** Integrate a database by leveraging `app/core/database.py` and `alembic/` migrations to store run history or catalog state.
+## Testing
+Run the automated suite from `backend/`:
+```bash
+pytest -q
+```
+
+## Deployment
+`backend/devops/runpod/deploy.sh` encapsulates the GPU deployment flow: syncing the repo, installing Python 3.11, exporting generation env vars, applying Alembic migrations, seeding data, and starting Uvicorn. Use it as the baseline for RunPod or other GPU orchestrators.【F:backend/devops/runpod/deploy.sh†L1-L134】

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,103 +1,49 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Frontend – Next.js App Router
 
-## Getting Started
+## Overview
+The frontend is a Next.js 15 application that delivers the client-facing stylist experience and an admin dashboard. It talks to the FastAPI service through a `/api/*` proxy, surfaces fabric and color metadata, orchestrates image generation, and lets merchandising teams curate inventory from `/admin`.【F:frontend/src/app/page.tsx†L1-L70】【F:frontend/src/app/admin/page.tsx†L1-L40】
 
-First, run the development server:
+## Core Features
+- **Guided styling flow** – `useVirtualStylist` fetches the catalog, manages selection state, triggers generations, and keeps loading and error feedback consistent across components.【F:frontend/src/hooks/useVirtualStylist.ts†L1-L201】
+- **Rich gallery experience** – Components such as `GeneratedImageGallery`, `ImageModal`, and `LoadingState` provide thumbnail grids, zoomable previews, and progress feedback for the rendered looks.【F:frontend/src/components/GeneratedImageGallery.tsx†L1-L120】【F:frontend/src/components/ImageModal.tsx†L1-L120】
+- **Fabric search & quick create** – The `/admin` route renders an interactive table that can search, toggle active status, and seed demo fabrics via the admin API helpers in `src/lib/adminApi.ts`.【F:frontend/src/app/admin/AdminTable.tsx†L1-L228】【F:frontend/src/lib/adminApi.ts†L1-L39】
+- **Device-friendly uploads** – `ImageUploadControls` expose camera and gallery pickers; previews are displayed with metadata so associates can blend reference imagery into conversations.【F:frontend/src/components/ImageUploadControls.tsx†L1-L160】
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-
-
-<!-- Start backend -->
-uvicorn app.main:app --reload --port 8000
-
-<!-- Start frontend -->
-npm run dev
-
----
-
-## Application Guide
-
-### Folder Structure
-
+## Project Structure
 ```
 frontend/
 ├── src/
-│   ├── app/                # App Router entrypoints (layout, page, globals.css)
-│   ├── components/         # Reusable UI building blocks
-│   ├── hooks/              # State + API orchestration (`useVirtualStylist`)
-│   ├── lib/                # REST client (`apiClient`), typed endpoints
-│   └── types/              # Shared TypeScript interfaces
-├── public/                 # Static assets (logos, icons)
-├── next.config.ts          # Custom Next.js config (images, rewrites, etc.)
-└── tsconfig.json           # Path aliases and compiler options
+│   ├── app/            # App Router pages (`page.tsx`, `/admin`)
+│   ├── components/     # Reusable UI (catalog selector, gallery, modals)
+│   ├── hooks/          # `useVirtualStylist` state machine
+│   ├── lib/            # API clients and typed helpers
+│   └── types/          # Shared TypeScript contracts
+├── public/             # Static assets (logos)
+├── next.config.ts      # API proxy rewrites and remote image patterns
+└── package.json        # Scripts and dependencies
 ```
 
-### Core Experience
+## Getting Started
+1. Install dependencies: `npm install`.
+2. Create `.env.local` to point the proxy and admin tooling to your backend:
+   ```env
+   NEXT_PUBLIC_RUNPOD_URL=http://localhost:8000
+   NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+   ```
+   `next.config.ts` rewrites `/api/:path*` to `NEXT_PUBLIC_RUNPOD_URL`, so the catalog and generate calls go straight to FastAPI while keeping relative URLs inside the app.【F:frontend/next.config.ts†L1-L21】【F:frontend/src/lib/apiClient.ts†L1-L38】
+3. Run the dev server: `npm run dev` (defaults to `http://localhost:3000`).
+4. Open `/admin` to access the merchandising console. It relies on the same `/api` proxy for `GET/POST/PATCH /admin/fabrics` requests.【F:frontend/src/lib/adminApi.ts†L1-L39】
 
-1. **Catalog Discovery** – `CatalogSelector` renders families and colors fetched from `GET /catalog/fabrics`. Selections are bubbled up through props into the main page state.
-2. **Styling Workflow** – `SearchTela` combines the selector, upload controls, and copy deck to guide the associate through fabric exploration.
-3. **Generation Trigger** – `GenerateButton` invokes the `useVirtualStylist` hook, which wraps the API call, loading states, and error handling.
-4. **Results Gallery** – `GeneratedImageGallery` and `ImageModal` display returned assets, providing zoom/download actions using the URLs served by FastAPI.
+## API Helpers
+- `fetchCatalog()` and `generateImages()` live in `src/lib/apiClient.ts` and return typed responses consumed by the hook and UI components.【F:frontend/src/lib/apiClient.ts†L1-L38】
+- Admin helpers (`listFabrics`, `createFabric`, `setFabricStatus`, `deactivateFabric`) use an Axios client configured with the `/api` base path, making the dashboard portable between local dev and RunPod deployments.【F:frontend/src/lib/adminApi.ts†L1-L39】
 
-### API Integration Details
-
-- `src/lib/apiClient.ts` centralizes fetch logic. It respects the `NEXT_PUBLIC_API_BASE` environment variable and automatically attaches JSON headers.
-- `src/lib/api.ts` and `src/lib/adminApi.ts` expose typed helpers such as `generateLook()` or `fetchCatalog()` to keep components declarative.
-- The hook `useVirtualStylist` manages debounce, optimistic loading, and exposes `generate`, `isLoading`, and `result` fields for the UI.
-
-### Styling System
-
-- Tailwind CSS powers utility classes (see `postcss.config.mjs` and `globals.css`).
-- Component-level styling leans on semantic classnames with Tailwind modifiers, ensuring the layout remains responsive on showroom tablets.
-- Add bespoke design tokens inside `globals.css` (CSS variables) for brand colors and typography.
-
-### Environment Variables
-
-Create a `.env.local` with:
-
-```
-NEXT_PUBLIC_API_BASE=http://localhost:8000
+## Testing & Quality
+Run ESLint to catch TypeScript and accessibility issues:
+```bash
+npm run lint
 ```
 
-For production, point this variable to the deployed FastAPI origin and ensure CORS allows the frontend hostname.
-
-### Development Tips
-
-- Run `npm run lint` to catch JSX/TypeScript issues early.
-- Use the React DevTools extension to inspect component state transitions, especially around `useVirtualStylist`.
-- When mocking the backend, you can stub responses in `apiClient.ts` or leverage MSW (Mock Service Worker) in future tests.
-
-### Deployment Notes
-
-- Vercel automatically reads environment variables prefixed with `NEXT_PUBLIC_` from the project dashboard.
-- To host elsewhere, generate a static build with `npm run build` and run `npm start` behind your preferred reverse proxy.
-- Ensure the backend exposes HTTPS URLs for generated images so that modern browsers do not block mixed content.
+## Deployment Notes
+- Vercel/Next proxies will automatically forward `/api/*` when `NEXT_PUBLIC_RUNPOD_URL` is set in the environment. For static hosting or custom deployments, configure an equivalent rewrite.
+- Ensure the backend exposes HTTPS asset URLs (or configure `NEXT_PUBLIC_API_BASE_URL`) so that the gallery can display generated images without mixed-content warnings.【F:frontend/src/app/admin/page.tsx†L1-L32】


### PR DESCRIPTION
## Summary
- rewrite the root README to document the SDXL pipeline, catalog admin flow, local setup, and deployment guidance
- update the backend README with environment variables, migration steps, API reference, and storage/generation details
- tailor the frontend README to describe the stylist workflow, admin dashboard, env configuration, and API helpers

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e3864e47d88331921c7dbf1afb5a1e