### PR TITLE
Use shared API base env var across frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,10 +27,9 @@ frontend/
 1. Install dependencies: `npm install`.
 2. Create `.env.local` to point the proxy and admin tooling to your backend:
    ```env
-   NEXT_PUBLIC_RUNPOD_URL=http://localhost:8000
-   NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+   NEXT_PUBLIC_API_BASE=http://localhost:8000
    ```
-   `next.config.ts` rewrites `/api/:path*` to `NEXT_PUBLIC_RUNPOD_URL`, so the catalog and generate calls go straight to FastAPI while keeping relative URLs inside the app.【F:frontend/next.config.ts†L1-L21】【F:frontend/src/lib/apiClient.ts†L1-L38】
+   `next.config.ts` rewrites `/api/:path*` to `NEXT_PUBLIC_API_BASE`, so the catalog and generate calls go straight to FastAPI while keeping relative URLs inside the app.【F:frontend/next.config.ts†L1-L24】【F:frontend/src/lib/apiClient.ts†L1-L38】
 3. Run the dev server: `npm run dev` (defaults to `http://localhost:3000`).
 4. Open `/admin` to access the merchandising console. It relies on the same `/api` proxy for `GET/POST/PATCH /admin/fabrics` requests.【F:frontend/src/lib/adminApi.ts†L1-L39】
 
@@ -45,5 +44,5 @@ npm run lint
 ```
 
 ## Deployment Notes
-- Vercel/Next proxies will automatically forward `/api/*` when `NEXT_PUBLIC_RUNPOD_URL` is set in the environment. For static hosting or custom deployments, configure an equivalent rewrite.
-- Ensure the backend exposes HTTPS asset URLs (or configure `NEXT_PUBLIC_API_BASE_URL`) so that the gallery can display generated images without mixed-content warnings.【F:frontend/src/app/admin/page.tsx†L1-L32】
+- Vercel/Next proxies will automatically forward `/api/*` when `NEXT_PUBLIC_API_BASE` is set in the environment. For static hosting or custom deployments, configure an equivalent rewrite.
+- Ensure the backend exposes HTTPS asset URLs (or configure `NEXT_PUBLIC_API_BASE`) so that the gallery can display generated images without mixed-content warnings.【F:frontend/src/app/admin/page.tsx†L1-L37】

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,13 +1,14 @@
 import type { NextConfig } from "next";
 
-const RUNPOD_URL = process.env.NEXT_PUBLIC_RUNPOD_URL; // e.g. https://lnqrev4dnktv7s-8000.proxy.runpod.net
+const RAW_API_BASE = process.env.NEXT_PUBLIC_API_BASE;
+const API_BASE = RAW_API_BASE ? RAW_API_BASE.replace(/\/+$/, "") : undefined;
 
 const nextConfig: NextConfig = {
     async rewrites() {
-    return RUNPOD_URL
+    return API_BASE
       ? [
           // Frontend calls /api/* and Next proxies it to RunPod
-          { source: "/api/:path*", destination: `${RUNPOD_URL}/:path*` },
+          { source: "/api/:path*", destination: `${API_BASE}/:path*` },
         ]
       : [];
   },

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -10,17 +10,17 @@ export default function AdminPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+    const base = process.env.NEXT_PUBLIC_API_BASE;
     if (!base) {
-      setError("Backend caido. Define NEXT_PUBLIC_API_BASE_URL o usa rewrites en vercel.json.");
+      setError("Backend caido. Define NEXT_PUBLIC_API_BASE o usa rewrites en vercel.json.");
       setItems([]);
       return;
     }
 
-    const controller = new AbortController();
     (async () => {
       try {
-        const data = await listFabrics({ limit: 50 });        setItems(data);
+        const data = await listFabrics();
+        setItems(data);
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "error desconocido";
         setError(`No se pudo conectar al backend: ${msg}`);

--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -6,7 +6,6 @@
 const API_BASE = (process.env.NEXT_PUBLIC_API_BASE || "").replace(/\/+$/, "");
 if (!API_BASE) {
   // Fail fast in dev so you don't silently hit / (current domain) by mistake
-  // eslint-disable-next-line no-console
   console.warn("[adminApi] NEXT_PUBLIC_API_BASE is not set");
 }
 

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -4,7 +4,6 @@
 
 const API_BASE = (process.env.NEXT_PUBLIC_API_BASE || "").replace(/\/+$/, "");
 if (!API_BASE) {
-  // eslint-disable-next-line no-console
   console.warn("[apiClient] NEXT_PUBLIC_API_BASE is not set");
 }
 


### PR DESCRIPTION
## Summary
- switch Next.js rewrite config to reuse NEXT_PUBLIC_API_BASE as the canonical backend origin
- update admin page and API helpers to read the same environment variable and tidy unused code
- refresh the frontend README instructions to document the single env var

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e47e3ef7008331b6f9f4d9cb44cfbc